### PR TITLE
JDP220701-13 - group entity - error fixed

### DIFF
--- a/src/main/java/com/kodilla/ecommercee/entity/Group.java
+++ b/src/main/java/com/kodilla/ecommercee/entity/Group.java
@@ -10,6 +10,7 @@ import javax.persistence.*;
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
+@Table(name = "`group`")
 public class Group {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/kodilla/ecommercee/repository/GroupRepository.java
+++ b/src/main/java/com/kodilla/ecommercee/repository/GroupRepository.java
@@ -1,0 +1,6 @@
+package com.kodilla.ecommercee.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GroupRepository {
+}


### PR DESCRIPTION
an error occured due to incorrect class (sql table) name. error fixed.
the word GROUP is reserved for sql queries, and can be used as table or variable name under certain contidions.
more details:
https://stackoverflow.com/questions/23446377/syntax-error-due-to-using-a-reserved-word-as-a-table-or-column-name-in-mysql